### PR TITLE
Fix for anchor footnotes breaking button spacing

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -240,8 +240,10 @@
     font-size: $font-size-large;
   }
 
-  // Vertically space out multiple block buttons
-  + .btn-block {
+  // Vertically space out multiple block buttons (including when footnotes for print media
+  // have been inserted between the buttons)
+  + .btn-block,
+  + .footnote + .btn-block {
     margin-top: ($space-large + $space-base);
   }
 }


### PR DESCRIPTION
Footnote elements inserted for `@media` print display were breaking the
vertical spacing between adjacent block buttons.